### PR TITLE
feat: combines advocate data

### DIFF
--- a/src/app/@favorites/default.tsx
+++ b/src/app/@favorites/default.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { Advocate } from "@/types/advocate";
+import { Chip } from "../components/Chip";
 
 // Mock favorites data
 
@@ -45,14 +46,25 @@ function FavoritesList() {
       {mockFavorites.map(favorite => (
         <div
           key={favorite.id}
-          className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 hover:shadow-md transition-shadow"
+          className="bg-white rounded-lg shadow-sm border border-[#E0E0E0] p-4 hover:shadow-md transition-shadow"
         >
           <div className="flex justify-between items-start mb-2">
             <h3 className="font-semibold text-gray-900">
               Dr. {favorite.firstName} {favorite.lastName}
             </h3>
-            <button className="text-red-500 hover:text-red-700 text-sm">
-              Remove
+            <button className="text-gray-500 hover:text-black text-xs">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="size-6"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M16.5 4.478v.227a48.816 48.816 0 0 1 3.878.512.75.75 0 1 1-.256 1.478l-.209-.035-1.005 13.07a3 3 0 0 1-2.991 2.77H8.084a3 3 0 0 1-2.991-2.77L4.087 6.66l-.209.035a.75.75 0 0 1-.256-1.478A48.567 48.567 0 0 1 7.5 4.705v-.227c0-1.564 1.213-2.9 2.816-2.951a52.662 52.662 0 0 1 3.369 0c1.603.051 2.815 1.387 2.815 2.951Zm-6.136-1.452a51.196 51.196 0 0 1 3.273 0C14.39 3.05 15 3.684 15 4.478v.113a49.488 49.488 0 0 0-6 0v-.113c0-.794.609-1.428 1.364-1.452Zm-.355 5.945a.75.75 0 1 0-1.5.058l.347 9a.75.75 0 1 0 1.499-.058l-.346-9Zm5.48.058a.75.75 0 1 0-1.498-.058l-.347 9a.75.75 0 0 0 1.5.058l.345-9Z"
+                  clip-rule="evenodd"
+                />
+              </svg>
             </button>
           </div>
           <p className="text-sm text-gray-600 mb-2">{favorite.city}</p>
@@ -61,12 +73,12 @@ function FavoritesList() {
           </p>
           <div className="flex flex-wrap gap-1">
             {favorite.specialties.map((specialty, index) => (
-              <span
+              <Chip
                 key={index}
-                className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded"
+
               >
                 {specialty}
-              </span>
+              </Chip>
             ))}
           </div>
         </div>

--- a/src/app/components/Chip.tsx
+++ b/src/app/components/Chip.tsx
@@ -1,0 +1,7 @@
+export const Chip = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <span className="bg-[rgba(67,130,113,0.5)] text-[rgba(67, 130, 113, 0.2)] text-xs px-2 py-1 rounded-2xl">
+      {children}
+    </span>
+  );
+};

--- a/src/app/components/SearchableAdvocatesTable.tsx
+++ b/src/app/components/SearchableAdvocatesTable.tsx
@@ -122,13 +122,10 @@ export default function SearchableAdvocatesTable({
           <table className="w-full border-collapse">
             <thead>
               <tr className="bg-[#285e50]/10 h-10 border-b border-gray-300 text-[#285e50]">
-                <TableHeader>First</TableHeader>
-                <TableHeader>Last</TableHeader>
-                <TableHeader>City</TableHeader>
-                <TableHeader>Degree</TableHeader>
+                <TableHeader textAlign="text-left" widthClass="w-[20%]">Advocate</TableHeader>
                 <TableHeader>Specialties</TableHeader>
                 <TableHeader>Experience</TableHeader>
-                <TableHeader>Contact</TableHeader>
+                <TableHeader widthClass="w-[12%]">Contact</TableHeader>
               </tr>
             </thead>
             <tbody>
@@ -137,10 +134,16 @@ export default function SearchableAdvocatesTable({
                   key={advocate.id}
                   className="hover:bg-gray-50 border-b border-gray-200"
                 >
-                  <TableRow>{advocate.firstName}</TableRow>
-                  <TableRow>{advocate.lastName}</TableRow>
-                  <TableRow>{advocate.city}</TableRow>
-                  <TableRow>{advocate.degree}</TableRow>
+                  <TableRow>
+                    <div className="space-y-1">
+                      <div className="font-medium text-gray-900">
+                        {advocate.firstName} {advocate.lastName}, {advocate.degree}
+                      </div>
+                      <div className="text-sm text-gray-600">
+                        {advocate.city}
+                      </div>
+                    </div>
+                  </TableRow>
                   <TableRow>
                     <div className="flex flex-wrap gap-1">
                       {advocate.specialties.map((specialty, index) => (

--- a/src/app/components/SearchableAdvocatesTable.tsx
+++ b/src/app/components/SearchableAdvocatesTable.tsx
@@ -7,6 +7,7 @@ import TableHeader from "@/app/components/TableHeader";
 import TableRow from "@/app/components/TableRow";
 import { Advocate } from "@/types/advocate";
 import { formatPhoneNumber } from "@/utils/phoneNumber";
+import { Chip } from "./Chip";
 
 interface SearchableAdvocatesTableProps {
   advocates: Advocate[];
@@ -122,7 +123,9 @@ export default function SearchableAdvocatesTable({
           <table className="w-full border-collapse">
             <thead>
               <tr className="bg-[#285e50]/10 h-10 border-b border-gray-300 text-[#285e50]">
-                <TableHeader textAlign="text-left" widthClass="w-[20%]">Advocate</TableHeader>
+                <TableHeader textAlign="text-left" widthClass="w-[20%]">
+                  Advocate
+                </TableHeader>
                 <TableHeader>Specialties</TableHeader>
                 <TableHeader>Experience</TableHeader>
                 <TableHeader widthClass="w-[12%]">Contact</TableHeader>
@@ -137,7 +140,8 @@ export default function SearchableAdvocatesTable({
                   <TableRow>
                     <div className="space-y-1">
                       <div className="font-medium text-gray-900">
-                        {advocate.firstName} {advocate.lastName}, {advocate.degree}
+                        {advocate.firstName} {advocate.lastName},{" "}
+                        {advocate.degree}
                       </div>
                       <div className="text-sm text-gray-600">
                         {advocate.city}
@@ -147,12 +151,7 @@ export default function SearchableAdvocatesTable({
                   <TableRow>
                     <div className="flex flex-wrap gap-1">
                       {advocate.specialties.map((specialty, index) => (
-                        <span
-                          key={index}
-                          className="bg-[rgba(67,130,113,0.5)] text-[rgba(67, 130, 113, 0.2)] text-xs px-2 py-1 rounded-2xl"
-                        >
-                          {specialty}
-                        </span>
+                        <Chip key={index}>{specialty}</Chip>
                       ))}
                     </div>
                   </TableRow>

--- a/src/app/components/TableHeader.tsx
+++ b/src/app/components/TableHeader.tsx
@@ -1,6 +1,16 @@
-const TableHeader = ({ children }: { children: React.ReactNode }) => {
+const TableHeader = ({ 
+  children, 
+  widthClass,
+  textAlign = "text-center"
+}: { 
+  children: React.ReactNode;
+  widthClass?: string;
+  textAlign?: "text-left" | "text-center" | "text-right";
+}) => {
   return (
-    <th className="px-4 py-2 text-xs tracking-wider uppercase font-medium text-gray-900">
+    <th 
+      className={`px-4 py-2 text-xs tracking-wider uppercase font-medium text-gray-900 ${widthClass || ''} ${textAlign}`}
+    >
       {children}
     </th>
   );

--- a/src/app/components/TableRow.tsx
+++ b/src/app/components/TableRow.tsx
@@ -1,5 +1,5 @@
 const TableRow = ({ children }: { children: React.ReactNode }) => {
-  return <td className="px-4 py-2 text-sm text-gray-600">{children}</td>;
+  return <td className="px-4 py-2 text-sm text-gray-600 align-text-top">{children}</td>;
 };
 
 export default TableRow;


### PR DESCRIPTION
# UI

- [x] Combine the advocate information 
- [x] Adjust the header widths with a configurable prop
- [x] Update the mocked data in the favorites

<img width="1476" height="822" alt="Screenshot 2025-08-09 at 00 27 00" src="https://github.com/user-attachments/assets/7401f28e-f985-493a-abb3-c2b8b261f763" />
